### PR TITLE
Default launch configuration now included in repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations":[
+    {
+      "name": "Debug COBOL",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/hello-dot-div",
+      "args": [],
+      "stopAtEntry": true,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit drops a plug-and-play launch.json for VS Code. Developers (or future me) can now debug eldercode-itunes in a real IDE without typing gdb manually.  Testing SYSTEM calls from inside COBOL just got surgical.